### PR TITLE
Rename HOSTNAME env to SERVER_HOSTNAME env.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Specify:
 - AWS_ACCESS_KEY_ID
 - AWS_SECRET_ACCESS_KEY
 - EMAIL_FROM (Address all email should be sent 'from')
-- HOSTNAME (name of the host where all email links should point)
+- SERVER_HOSTNAME (name of the host where all email links should point)
 
 ### Rollbar Integration
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,6 @@ module Iuf
     config.rollbar_access_token = ENV['ROLLBAR_ACCESS_TOKEN']
     config.rollbar_env = ENV.fetch('ROLLBAR_ENV') { Rails.env }
 
-    config.hostname = ENV.fetch('HOSTNAME') { 'localhost' }
+    config.server_hostname = ENV.fetch('SERVER_HOSTNAME') { 'localhost' }
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,5 +111,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-  config.action_mailer.default_url_options = { host: Rails.configuration.hostname }
+  config.action_mailer.default_url_options = { host: Rails.configuration.server_hostname }
 end


### PR DESCRIPTION
By default, dotenv doesn't overwrite variables declared in the environment.
And, or AWS, there is a HOSTNAME variable pre-set