### PR TITLE
Capture transaction from server, ensuring that we mark as paid correctly

### DIFF
--- a/app/controllers/paypal_controller.rb
+++ b/app/controllers/paypal_controller.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
-# After a payment callback is received, before we consider it
-# paid, we check to ensure that it's a real payment.
+# After a payment is created, but before it is captured (charged)
+# call this controller to capture/log the payment
 class PaypalController < ApplicationController
   # Ignore CSRF Token on this request
   skip_before_action :verify_authenticity_token
   before_action :skip_authorization
 
-  def confirm
-    PaypalConfirmer.new.confirm(params[:orderID])
+  # Create a transaction and capture payment
+  def create
+    result = PaypalConfirmer.new.capture(params[:orderID])
+    if result
+      PaypalConfirmer.new.create_payment(result)
+      render json: { success: true, message: 'Order processed' }
+    else
+      render json: { success: false, message: 'error processoring order' }
+    end
   end
 end

--- a/app/lib/paypal_confirmer.rb
+++ b/app/lib/paypal_confirmer.rb
@@ -7,36 +7,60 @@
 class PaypalConfirmer
   include PayPalCheckoutSdk::Orders
 
-  # Retrieve order details from paypal
-  # and then confirm the payment in our db
-  def confirm(order_id)
-    paypal_order_details = get_order_details(order_id)
-    create_payment(paypal_order_details)
-  end
-
+  # Create a payment record in our database
+  # for the payment provided
   def create_payment(paypal_order_details) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
-    return false unless paypal_order_details[:status_code] == 200
-
-    result = paypal_order_details[:result]
-    purchase_unit = result[:purchase_units][0]
+    purchase_unit = paypal_order_details[:purchase_units][0]
     custom_id = purchase_unit[:custom_id]
     member = Member.find_by(id: custom_id)
-    return false if member.nil?
+    if member.nil?
+      Rollbar.debug('Unable to find member to mark paid', custom_id: custom_id)
+      return false
+    end
 
     member.payments.create(
-      order_id: result[:id],
+      order_id: paypal_order_details[:id],
       amount_cents: purchase_unit[:amount][:value].to_f * 100,
       currency: purchase_unit[:amount][:currency_code],
-      received_at: result[:create_time]
+      received_at: paypal_order_details[:create_time]
     )
     member.update(iuf_id: MemberNumberCreator.allocate_number) if member.iuf_id.blank?
   end
 
+  # unused function which allows us to look up an order from paypal
   def get_order_details(order_id)
     # Create an order request to get the order details from PayPal
     request = OrdersGetRequest.new(order_id)
     # Call PayPal to get the transaction
     result = PayPalClient.client.execute(request)
     PayPalClient.openstruct_to_hash(result)
+  end
+
+  # ===================================
+
+  # Capture a given order in paypal
+  #
+  # params: order_id - paypal Order number
+  #                    used to fetch/capture a payment
+  #
+  # On success, return the order representation
+  # as a hash object
+  # On failure return false
+  def capture(order_id) # rubocop:disable Metrics/MethodLength
+    request = OrdersCaptureRequest.new(order_id)
+    request.prefer('return=representation')
+    begin
+      response = PayPalClient.client.execute(request)
+      unless [200, 201].include?(response.status_code)
+        Rollbar.debug('Unsuccessful paypal capture attempt', capture: response)
+        return false
+      end
+
+      return PayPalClient.openstruct_to_hash(response.result)
+    rescue StandardError => e
+      Rollbar.error(e)
+    end
+
+    false
   end
 end

--- a/app/views/members/_payment_form.html.erb
+++ b/app/views/members/_payment_form.html.erb
@@ -18,21 +18,19 @@
       });
     },
     onApprove: function(data, actions) {
-      // Capture the funds from the transaction
-      return actions.order.capture().then(function(details) {
-        // Show a success message to your buyer
-        // alert('Transaction completed by ' + details.payer.name.given_name);
-        return fetch("<%= paypal_confirmation_path %>", {
-          method: "post",
-          headers: {
-            'content-type': 'application/json'
-          },
-          body: JSON.stringify({
-            orderID: data.orderID
-          })
-        }).then(function() {
-          location.reload();
-        });
+      return fetch("<%= paypal_transaction_path %>", {
+        method: 'post',
+        headers: {
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          orderID: data.orderID
+        })
+      }).then(function(res) {
+        return res.json();
+      }).then(function(details) {
+        location.reload();
+        return;
       });
     }
   }).render('#paypal-button-container');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   root to: 'home#index'
   get '/privacy-policy', to: 'home#privacy_policy'
 
-  post '/paypal-transaction-complete', as: :paypal_confirmation, to: 'paypal#confirm'
+  post '/create-paypal-transaction', as: :paypal_transaction, to: 'paypal#create'
 
   post '/api/member_status', to: 'api/members#status'
 end

--- a/spec/lib/paypal_confirmer_spec.rb
+++ b/spec/lib/paypal_confirmer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PaypalConfirmer, type: :model do
     let!(:member) { create(:member) }
 
     it 'creates a payment' do
-      described_class.new.create_payment(incoming_message)
+      described_class.new.create_payment(incoming_message[:result])
       expect(Payment.count).to eq(1)
     end
   end


### PR DESCRIPTION
Instead of relying upon the client browser to call the server when the capture is completed, let's pass the order to the server, and have the server perform the capture with paypal directly, and then mark the member as paid immediately.