### PR TITLE
Revert "update pg gem"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,7 @@ GEM
     paypal-checkout-sdk (1.0.3)
       paypalhttp (~> 1.0.0)
     paypalhttp (1.0.0)
-    pg (1.4.4)
+    pg (1.2.3)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)


### PR DESCRIPTION
Reverts rdunlop/iuf-membership#356

Because the server needs to have a newer version of postgres installed to support this. (see 1.3.0 release notes).