### PR TITLE
Revert "Bump pg from 1.2.3 to 1.4.6"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,7 +241,7 @@ GEM
     paypal-checkout-sdk (1.0.4)
       paypalhttp (~> 1.0.1)
     paypalhttp (1.0.1)
-    pg (1.4.6)
+    pg (1.2.3)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)


### PR DESCRIPTION
Reverts rdunlop/iuf-membership#430

We have a pg-version issue on the server preventing us from merging this right now.