### PR TITLE
Add payment expiration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,7 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Exclude:
     - "db/migrate/*.rb"
+    - "app/controllers/api/members_controller.rb"
 
 Metrics/AbcSize:
   Max: 18

--- a/app/controllers/api/members_controller.rb
+++ b/app/controllers/api/members_controller.rb
@@ -10,7 +10,8 @@ module Api
       member = MemberFinder.find_paid(
         first_name: params[:first_name],
         last_name: params[:last_name],
-        birthdate: params[:birthdate]
+        birthdate: params[:birthdate],
+        eventdate: params[:eventdate]
       )
 
       if member

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -32,7 +32,7 @@ class MembersController < ApplicationController
     @member = Member.find(params[:id])
     authorize(@member)
 
-    @recent_membership_purchase = @member.active? && @member
+    @recent_membership_purchase = @member.recent_purchase? && @member
   end
 
   def edit

--- a/app/dashboards/member_dashboard.rb
+++ b/app/dashboards/member_dashboard.rb
@@ -23,7 +23,8 @@ class MemberDashboard < Administrate::BaseDashboard
     contact_email: Field::String,
     created_at: Field::DateTime.with_options(export: false),
     updated_at: Field::DateTime.with_options(export: false),
-    iuf_id: Field::Number.with_options(export: false)
+    iuf_id: Field::Number.with_options(export: false),
+    active?: Field::Boolean
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -50,6 +51,7 @@ class MemberDashboard < Administrate::BaseDashboard
     contact_email
     alternate_first_name
     alternate_last_name
+    active?
     payments
     created_at
     updated_at

--- a/app/dashboards/payment_dashboard.rb
+++ b/app/dashboards/payment_dashboard.rb
@@ -19,7 +19,10 @@ class PaymentDashboard < Administrate::BaseDashboard
     amount_cents: Field::Number,
     currency: Field::String,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
+    start_date: Field::Date,
+    expiration_date: Field::Date,
+    active?: Field::Boolean
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -31,6 +34,7 @@ class PaymentDashboard < Administrate::BaseDashboard
     id
     member
     order_id
+    active?
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -44,6 +48,8 @@ class PaymentDashboard < Administrate::BaseDashboard
     currency
     created_at
     updated_at
+    start_date
+    expiration_date
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -55,6 +61,7 @@ class PaymentDashboard < Administrate::BaseDashboard
     received_at
     amount_cents
     currency
+    start_date
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/lib/paypal_confirmer.rb
+++ b/app/lib/paypal_confirmer.rb
@@ -18,12 +18,15 @@ class PaypalConfirmer
       return false
     end
 
-    member.payments.create(
+    current_expiration_date = member.expiration_date
+    payment = member.payments.create(
       order_id: paypal_order_details[:id],
       amount_cents: purchase_unit[:amount][:value].to_f * 100,
       currency: purchase_unit[:amount][:currency_code],
       received_at: paypal_order_details[:create_time]
     )
+
+    payment.update(start_date: current_expiration_date) if current_expiration_date
     member.update(iuf_id: MemberNumberCreator.allocate_number) if member.iuf_id.blank?
   end
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -37,7 +37,7 @@ class Member < ApplicationRecord
     [first_name, last_name].join(' ')
   end
 
-  def active?(as_of_date = Date.current)
+  def active?(as_of_date = DateTime.current)
     payments.any? do |payment|
       payment.active?(as_of_date)
     end
@@ -53,6 +53,10 @@ class Member < ApplicationRecord
 
   def last_name=(name)
     super(name&.strip)
+  end
+
+  def expiration_date
+    payments.select(&:active?).map(&:expiration_date).max
   end
 
   private

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -37,8 +37,14 @@ class Member < ApplicationRecord
     [first_name, last_name].join(' ')
   end
 
-  def active?
-    payments.any?
+  def active?(as_of_date = Date.current)
+    payments.any? do |payment|
+      payment.active?(as_of_date)
+    end
+  end
+
+  def recent_purchase?
+    payments.select(&:recent?)
   end
 
   def first_name=(name)

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -28,7 +28,22 @@ class Payment < ApplicationRecord
 
   scope :received, -> { where.not(received_at: nil) }
 
+  # is this payment still covering the user's membership
+  def active?(as_of_date = Date.current)
+    expiration_date > as_of_date
+  end
+
   def recent?
     received_at > 2.days.ago
+  end
+
+  def expiration_date
+    if created_at < Date.new(2021)
+      # Because of Covid19, the Unicon was delayed 2 years
+      # We extend their payment validity to the end of Unicon in 2022
+      Date.new(2022, 8, 6) # Final day of Unicon 2022
+    else
+      created_at + 2.years
+    end
   end
 end

--- a/app/services/member_finder.rb
+++ b/app/services/member_finder.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-# Search for a member given 3 parameters.
+# Search for a member given 3 parameters, and 1 event date.
 # Deals with figuring out how to match the given
 # parameters with the existing data, ignoring unimportant
 # variations
 class MemberFinder
-  def self.find_paid(first_name:, last_name:, birthdate:)
+  def self.find_paid(first_name:, last_name:, birthdate:, eventdate:)
     find_all(
       first_name: first_name,
       last_name: last_name,
       birthdate: birthdate
-    ).select(&:active?).first
+    ).select { |member| member.active?(eventdate) }.first
   end
 
   def self.find_all(first_name:, last_name:, birthdate:) # rubocop:disable Metrics/MethodLength

--- a/app/services/member_finder.rb
+++ b/app/services/member_finder.rb
@@ -6,11 +6,12 @@
 # variations
 class MemberFinder
   def self.find_paid(first_name:, last_name:, birthdate:, eventdate:)
+    edate = Date.parse(eventdate)
     find_all(
       first_name: first_name,
       last_name: last_name,
       birthdate: birthdate
-    ).select { |member| member.active?(eventdate) }.first
+    ).select { |member| member.active?(edate) }.first
   end
 
   def self.find_all(first_name:, last_name:, birthdate:) # rubocop:disable Metrics/MethodLength

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -18,24 +18,32 @@
     <% end %>
   </div>
 </div>
+
 <% if @member.active? %>
   <div class="alert alert-info">
-    <b>Active IUF Member for Unicon 2020</b>
+    <b>Active IUF Member</b>
+    <br>
+    <b>Note:</b> If you've been sent here but your membership is currently active, this is probably because your membership will expire before the end of the upcoming UNICON. Please purchase a new membership to continue.
+    <br>
+    Using Paypal below, pay for your membership now.
   </div>
-  <% if @member.payments.any? %>
-    <h2>Payments:</h2>
-    <ul>
-      <% @member.payments.each do |payment| %>
-        <li>Invoice Number <%= payment.id %></li>
-      <% end %>
-    </ul>
-  <% end %>
 <% else %>
   <div class="alert alert-danger">
     <b>Unpaid Member</b>
     Using Paypal below, pay for your membership now.
   </div>
-  <div class="container">
-    <%= render "payment_form", member: @member %>
-  </div>
+<% end %>
+
+<div class="container">
+  <%= render "payment_form", member: @member %>
+</div>
+
+<hr>
+<% if @member.payments.any? %>
+  <h2>Payments:</h2>
+  <ul>
+    <% @member.payments.each do |payment| %>
+      <li>Invoice Number <%= payment.id %> (received: <%= payment.created_at %>, expires_at: <%= payment.expiration_date %></li>
+    <% end %>
+  </ul>
 <% end %>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -23,6 +23,8 @@
   <div class="alert alert-info">
     <b>Active IUF Member</b>
     <br>
+    Your membership expires <%= @member.expiration_date.to_date %>
+    <br>
     <b>Note:</b> If you've been sent here but your membership is currently active, this is probably because your membership will expire before the end of the upcoming UNICON. Please purchase a new membership to continue.
     <br>
     Using Paypal below, pay for your membership now.
@@ -43,7 +45,7 @@
   <h2>Payments:</h2>
   <ul>
     <% @member.payments.each do |payment| %>
-      <li>Invoice Number <%= payment.id %> (received: <%= payment.created_at %>, expires_at: <%= payment.expiration_date %></li>
+      <li>Invoice Number <%= payment.id %> (received: <%= payment.created_at.to_date %>, start_date: <%= payment.start_date.to_date %>, expires_at: <%= payment.expiration_date.to_date %></li>
     <% end %>
   </ul>
 <% end %>

--- a/db/migrate/20230611151602_add_start_date_to_payment.rb
+++ b/db/migrate/20230611151602_add_start_date_to_payment.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddStartDateToPayment < ActiveRecord::Migration[6.1]
+  def change
+    add_column :payments, :start_date, :datetime
+
+    reversible do |direction|
+      direction.up do
+        execute 'UPDATE payments SET start_date = created_at'
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_29_125554) do
+ActiveRecord::Schema.define(version: 2023_06_11_151602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 2019_08_29_125554) do
     t.string "currency"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "start_date"
     t.index ["member_id"], name: "index_payments_on_member_id"
   end
 

--- a/spec/lib/paypal_confirmer_spec.rb
+++ b/spec/lib/paypal_confirmer_spec.rb
@@ -29,5 +29,23 @@ RSpec.describe PaypalConfirmer, type: :model do
       described_class.new.create_payment(incoming_message[:result])
       expect(Payment.count).to eq(1)
     end
+
+    context 'when the member already has an OLD payment' do
+      let!(:payment) { create(:payment, member: member, start_date: 3.years.ago) }
+
+      it 'creates a payment with start_date = created_at' do
+        described_class.new.create_payment(incoming_message[:result])
+        expect(Payment.last.start_date).to eq(Payment.last.created_at)
+      end
+    end
+
+    context 'when the member has an ACTIVE payment' do
+      let!(:payment) { create(:payment, member: member, start_date: 1.day.ago) }
+
+      it 'creates a payment with start_date = expiration_date' do
+        described_class.new.create_payment(incoming_message[:result])
+        expect(Payment.last.start_date.to_date).to eq(payment.expiration_date.to_date)
+      end
+    end
   end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -55,6 +55,14 @@ RSpec.describe Member, type: :model do
       end
     end
 
+    context 'with a payment in 2019' do
+      let!(:payment) { create(:payment, member: member, created_at: Date.new(2019, 1, 1)) }
+
+      it 'is not active' do
+        expect(member).not_to be_active
+      end
+    end
+
     context 'with a payment' do
       let!(:payment) { create(:payment, member: member) }
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -38,4 +38,16 @@ RSpec.describe Payment, type: :model do
       it { should_not be_recent }
     end
   end
+
+  describe '#start_date' do
+    it 'sets start date' do
+      expect(payment.reload.start_date).not_to be_nil
+    end
+  end
+
+  context '#expiration_date' do
+    it 'is relative to the start_date' do
+      expect(payment.expiration_date).to be_within(2.seconds).of(payment.start_date + 2.years)
+    end
+  end
 end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'API Specs', type: :request do
-  let(:params) { { first_name: 'Bob', last_name: 'Smith', birthdate: '2000-12-22' } }
+  let(:params) { { first_name: 'Bob', last_name: 'Smith', birthdate: '2000-12-22', eventdate: '2024-07-26' } }
 
   def do_action(params)
     headers = {
@@ -27,8 +27,21 @@ RSpec.describe 'API Specs', type: :request do
       end
     end
 
+    context "when the user has a payment which is active, but won't be active by event date" do
+      let!(:payment) { create(:payment, member: member, created_at: Date.new(2024, 7, 26) - 2.years - 2.days) }
+
+      before do
+        member.update(iuf_id: 4)
+      end
+
+      it 'responds with not-member' do
+        do_action(params)
+        expect(response.parsed_body).to eq('member' => false)
+      end
+    end
+
     context 'When the user is active' do
-      let!(:payment) { create(:payment, member: member) }
+      let!(:payment) { create(:payment, member: member, created_at: Date.new(2024, 7, 1)) }
       before do
         member.update(iuf_id: 4)
       end

--- a/spec/services/member_finder_spec.rb
+++ b/spec/services/member_finder_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe MemberFinder, type: :model do
       let!(:payment) { create(:payment, member: member2) }
 
       it 'returns the _paid_ member first' do
-        expect(described_class.find_paid(first_name: 'Bob', last_name: 'Smith', birthdate: '2000-01-02', eventdate: '2022-07-26')).to eq(member2)
+        expect(described_class.find_paid(first_name: 'Bob', last_name: 'Smith', birthdate: '2000-01-02', eventdate: Date.current.strftime('%Y-%m-%d'))).to eq(member2)
       end
     end
   end

--- a/spec/services/member_finder_spec.rb
+++ b/spec/services/member_finder_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe MemberFinder, type: :model do
   end
 
   context 'with a payment for the member' do
-    let!(:payment) { create(:payment, member: member) }
+    let!(:payment) { create(:payment, member: member, created_at: Date.new(2022, 7, 1)) }
 
     context 'when the name matches exactly' do
       let(:first_name) { 'Bob' }
       let(:last_name) { 'Smith' }
 
       it 'can find the member' do
-        expect(described_class.find_paid(first_name: first_name, last_name: last_name, birthdate: '2000-01-02')).to eq(member)
+        expect(described_class.find_paid(first_name: first_name, last_name: last_name, birthdate: '2000-01-02',  eventdate: '2022-07-26')).to eq(member)
       end
     end
 
@@ -29,7 +29,7 @@ RSpec.describe MemberFinder, type: :model do
       let(:last_name) { '  Smith  ' }
 
       it 'can find the member' do
-        expect(described_class.find_paid(first_name: first_name, last_name: last_name, birthdate: '2000-01-02')).to eq(member)
+        expect(described_class.find_paid(first_name: first_name, last_name: last_name, birthdate: '2000-01-02',  eventdate: '2022-07-26')).to eq(member)
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe MemberFinder, type: :model do
       let(:last_name) { 'smith' }
 
       it 'can find the member' do
-        expect(described_class.find_paid(first_name: first_name, last_name: last_name, birthdate: '2000-01-02')).to eq(member)
+        expect(described_class.find_paid(first_name: first_name, last_name: last_name, birthdate: '2000-01-02',  eventdate: '2022-07-26')).to eq(member)
       end
     end
 
@@ -51,29 +51,29 @@ RSpec.describe MemberFinder, type: :model do
       end
 
       it 'can find with the accents' do
-        expect(described_class.find_paid(first_name: 'Olaf', last_name: 'Svgürst', birthdate: '2000-01-02')).to eq(member)
+        expect(described_class.find_paid(first_name: 'Olaf', last_name: 'Svgürst', birthdate: '2000-01-02',  eventdate: '2022-07-26')).to eq(member)
       end
 
       it 'Can find without the accents' do
-        expect(described_class.find_paid(first_name: 'Olaf', last_name: 'Svgurst', birthdate: '2000-01-02')).to eq(member)
+        expect(described_class.find_paid(first_name: 'Olaf', last_name: 'Svgurst', birthdate: '2000-01-02',  eventdate: '2022-07-26')).to eq(member)
       end
     end
 
     context 'when searching by alternate first name' do
       it 'finds the same record' do
-        expect(described_class.find_paid(first_name: 'Robert', last_name: 'Smith', birthdate: '2000-01-02')).to eq(member)
+        expect(described_class.find_paid(first_name: 'Robert', last_name: 'Smith', birthdate: '2000-01-02',  eventdate: '2022-07-26')).to eq(member)
       end
     end
 
     context 'when searching by alternate last name' do
       it 'finds the same record' do
-        expect(described_class.find_paid(first_name: 'Bob', last_name: 'Smith-Jones', birthdate: '2000-01-02')).to eq(member)
+        expect(described_class.find_paid(first_name: 'Bob', last_name: 'Smith-Jones', birthdate: '2000-01-02', eventdate: '2022-07-26')).to eq(member)
       end
     end
 
     context 'when searching by alternate names' do
       it 'finds the same record' do
-        expect(described_class.find_paid(first_name: 'Robert', last_name: 'Smith-Jones', birthdate: '2000-01-02')).to eq(member)
+        expect(described_class.find_paid(first_name: 'Robert', last_name: 'Smith-Jones', birthdate: '2000-01-02', eventdate: '2022-07-26')).to eq(member)
       end
     end
   end
@@ -90,7 +90,7 @@ RSpec.describe MemberFinder, type: :model do
       let!(:payment) { create(:payment, member: member2) }
 
       it 'returns the _paid_ member first' do
-        expect(described_class.find_paid(first_name: 'Bob', last_name: 'Smith', birthdate: '2000-01-02')).to eq(member2)
+        expect(described_class.find_paid(first_name: 'Bob', last_name: 'Smith', birthdate: '2000-01-02', eventdate: '2022-07-26')).to eq(member2)
       end
     end
   end


### PR DESCRIPTION
Adds ability to have IUF membership "expire" after 2 years (with COVID-time extensions).
Adds ability to pay for a new membership
Adds ability for admin user to view/manage the "Start_date" for a new payment