### PR TITLE
downgrade nokogiri.

### DIFF
--- a/.bundlerauditignore
+++ b/.bundlerauditignore
@@ -1,2 +1,4 @@
 # there is no fixed version in rails 6.x
 CVE-2024-54133
+# Need to upgrade nokogiri (need new GLIBC to do so)
+GHSA-r95h-9x8f-r3f7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,7 @@ GEM
       net-protocol
     net-ssh (7.2.0)
     nio4r (2.7.4)
-    nokogiri (1.18.1)
+    nokogiri (1.15.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     orm_adapter (0.5.0)


### PR DESCRIPTION
Our production server doesn't support newer versions due to old GLIBC