### PR TITLE
a recent concurrent-ruby upgrade stopped requiring logger.

### DIFF
--- a/bin/shakapacker
+++ b/bin/shakapacker
@@ -4,6 +4,7 @@ ENV["RAILS_ENV"] ||= "development"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
 
 require "bundler/setup"
+require "logger"
 require "shakapacker"
 require "shakapacker/webpack_runner"
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -3,4 +3,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'logger'
 require 'bootsnap/setup' # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
This caused isssue.
https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror