### PR TITLE
Add rake task which will run yarn:install before assets precompile.

### DIFF
--- a/lib/tasks/yarn.rake
+++ b/lib/tasks/yarn.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :yarn do
+  desc 'Yarn Install'
+  task install: :environment do
+    sh 'yarn install'
+  end
+end
+
+Rake::Task['assets:precompile'].enhance ['yarn:install']


### PR DESCRIPTION
rails 7 removed this step from occurring automatically